### PR TITLE
chore: fix file name discrepancy in the code

### DIFF
--- a/packages/ast/scripts/test-ast.js
+++ b/packages/ast/scripts/test-ast.js
@@ -1,5 +1,5 @@
 // This file is a demonstation of how ast package works. In order to try it yourself you need:
-// 1. Create a 'fixture.tx' file in the same directory as this file and write any TypeScript to it.
+// 1. Create a 'fixture.ts' file in the same directory as this file and write any TypeScript to it.
 // 2. cd into `packages/ast`.
 // 3. Run `yarn test:ast`.
 // `test-output.json` will be created containing an abstract syntax tree of the `fixture.ts` file.


### PR DESCRIPTION
I noticed that in the comments, the file was referred to as `fixture.tx`, but in the actual code, it's named `fixture.ts`.
I’ve corrected the comment to match the file name used in the code.