### PR TITLE
Fix typos in proto files

### DIFF
--- a/__fixtures__/chain2/cosmos/authz/v1beta1/event.proto
+++ b/__fixtures__/chain2/cosmos/authz/v1beta1/event.proto
@@ -6,7 +6,7 @@ option go_package = "github.com/cosmos/cosmos-sdk/x/authz";
 
 // EventGrant is emitted on Msg/Grant
 message EventGrant {
-  // Msg type URL for which an autorization is granted
+  // Msg type URL for which an authorization is granted
   string msg_type_url = 2;
   // Granter account address
   string granter = 3;
@@ -16,7 +16,7 @@ message EventGrant {
 
 // EventRevoke is emitted on Msg/Revoke
 message EventRevoke {
-  // Msg type URL for which an autorization is revoked
+  // Msg type URL for which an authorization is revoked
   string msg_type_url = 2;
   // Granter account address
   string granter = 3;

--- a/__fixtures__/chain2/cosmos/gov/v1beta1/genesis.proto
+++ b/__fixtures__/chain2/cosmos/gov/v1beta1/genesis.proto
@@ -17,10 +17,10 @@ message GenesisState {
   repeated Vote votes = 3 [(gogoproto.castrepeated) = "Votes", (gogoproto.nullable) = false];
   // proposals defines all the proposals present at genesis.
   repeated Proposal proposals = 4 [(gogoproto.castrepeated) = "Proposals", (gogoproto.nullable) = false];
-  // params defines all the paramaters of related to deposit.
+  // params defines all the parameters of related to deposit.
   DepositParams deposit_params = 5 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"deposit_params\""];
-  // params defines all the paramaters of related to voting.
+  // params defines all the parameters of related to voting.
   VotingParams voting_params = 6 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"voting_params\""];
-  // params defines all the paramaters of related to tally.
+  // params defines all the parameters of related to tally.
   TallyParams tally_params = 7 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"tally_params\""];
 }

--- a/__fixtures__/osmojs/ics23/proto/cosmos/ics23/v1/proofs.proto
+++ b/__fixtures__/osmojs/ics23/proto/cosmos/ics23/v1/proofs.proto
@@ -44,7 +44,7 @@ enum LengthOp {
 
 /**
 ExistenceProof takes a key and a value and a set of steps to perform on it.
-The result of peforming all these steps will provide a "root hash", which can
+The result of performing all these steps will provide a "root hash", which can
 be compared to the value in a header.
 
 Since it is computationally infeasible to produce a hash collission for any of the used

--- a/__fixtures__/osmojs/osmosis/proto/osmosis/concentrated-liquidity/pool-model/query.proto
+++ b/__fixtures__/osmojs/osmosis/proto/osmosis/concentrated-liquidity/pool-model/query.proto
@@ -29,7 +29,7 @@ service Query {
         "/osmosis/concentratedliquidity/v1beta1/params";
   }
 
-  // UserPositions returns all concentrated postitions of some address.
+  // UserPositions returns all concentrated positions of some address.
   rpc UserPositions(QueryUserPositionsRequest)
       returns (QueryUserPositionsResponse) {
     option (google.api.http).get =

--- a/__fixtures__/osmojs/wasmd/proto/cosmwasm/wasm/v1/proposal.proto
+++ b/__fixtures__/osmojs/wasmd/proto/cosmwasm/wasm/v1/proposal.proto
@@ -89,7 +89,7 @@ message InstantiateContract2Proposal {
   string title = 1;
   // Description is a human readable text
   string description = 2;
-  // RunAs is the address that is passed to the contract's enviroment as sender
+  // RunAs is the address that is passed to the contract's environment as sender
   string run_as = 3;
   // Admin is an optional address that can execute migrations
   string admin = 4;


### PR DESCRIPTION
This PR fixes various typos in comments across multiple proto files, including misspellings of "authorization", "parameters", "performing", "positions", and "environment".
