### PR TITLE
fix: named of Endo base64 imports

### DIFF
--- a/__fixtures__/misc/output-base64/google/protobuf/any.ts
+++ b/__fixtures__/misc/output-base64/google/protobuf/any.ts
@@ -1,7 +1,7 @@
 import { BinaryReader, BinaryWriter } from "../../binary";
 import { isSet, DeepPartial } from "../../helpers";
-import { encodeBase64 as bytesFromBase64 } from "@endo/base64";
-import { decodeBase64 as base64FromBytes } from "@endo/base64";
+import { decodeBase64 as bytesFromBase64 } from "@endo/base64";
+import { encodeBase64 as base64FromBytes } from "@endo/base64";
 import { JsonSafe } from "../../json-safe";
 export const protobufPackage = "google.protobuf";
 /**

--- a/__fixtures__/misc/output-base64/google/protobuf/descriptor.ts
+++ b/__fixtures__/misc/output-base64/google/protobuf/descriptor.ts
@@ -1,8 +1,8 @@
 import { BinaryReader, BinaryWriter } from "../../binary";
 import { JsonSafe } from "../../json-safe";
 import { DeepPartial, isSet } from "../../helpers";
-import { encodeBase64 as bytesFromBase64 } from "@endo/base64";
-import { decodeBase64 as base64FromBytes } from "@endo/base64";
+import { decodeBase64 as bytesFromBase64 } from "@endo/base64";
+import { encodeBase64 as base64FromBytes } from "@endo/base64";
 export const protobufPackage = "google.protobuf";
 export enum FieldDescriptorProto_Type {
   /**

--- a/__fixtures__/misc/output-base64/misc/all_fields.ts
+++ b/__fixtures__/misc/output-base64/misc/all_fields.ts
@@ -5,8 +5,8 @@ import { Timestamp, TimestampAmino, TimestampSDKType } from "../google/protobuf/
 import { BinaryReader, BinaryWriter } from "../binary";
 import { toTimestamp, fromTimestamp, isSet, DeepPartial } from "../helpers";
 import { Decimal } from "@cosmjs/math";
-import { encodeBase64 as bytesFromBase64 } from "@endo/base64";
-import { decodeBase64 as base64FromBytes } from "@endo/base64";
+import { decodeBase64 as bytesFromBase64 } from "@endo/base64";
+import { encodeBase64 as base64FromBytes } from "@endo/base64";
 import { JsonSafe } from "../json-safe";
 import { toUtf8, fromBase64, fromUtf8, toBase64 } from "@cosmjs/encoding";
 import { encodePubkey, decodePubkey } from "@cosmjs/proto-signing";

--- a/packages/telescope/src/generators/customize-utils.ts
+++ b/packages/telescope/src/generators/customize-utils.ts
@@ -38,13 +38,13 @@ export const plugin = (builder: TelescopeBuilder) => {
     UTILS.base64FromBytes = {
       type: 'import',
       path: '@endo/base64',
-      name: 'decodeBase64',
+      name: 'encodeBase64',
       importAs: 'base64FromBytes',
     };
     UTILS.bytesFromBase64 = {
       type: 'import',
       path: '@endo/base64',
-      name: 'encodeBase64',
+      name: 'ecodeBase64',
       importAs: 'bytesFromBase64',
     };
   } else {


### PR DESCRIPTION
The names  from https://github.com/hyperweb-io/telescope/commit/057f166b4840084b1cff24b1861afa1bb6091401 got crossed in the PR that landed,
- https://github.com/hyperweb-io/telescope/pull/654